### PR TITLE
Included Arduino.h at the top of all vehicle config files

### DIFF
--- a/src/1_adjustmentsVehicle.h
+++ b/src/1_adjustmentsVehicle.h
@@ -1,3 +1,5 @@
+#include <Arduino.h>
+
 // VEHICLE SETTINGS ****************************************************************************************************
 // Select the vehicle preset you want (uncomment the one you want, remove //, never more than one)
 

--- a/src/vehicles/00_Master.h
+++ b/src/vehicles/00_Master.h
@@ -1,4 +1,7 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds, which are not already used in pre made configurations
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission.
+// This master file is containing all available sounds, which are not already used in pre made configurations
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/1000HpScaniaV8.h
+++ b/src/vehicles/1000HpScaniaV8.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/1965FordMustangV8.h
+++ b/src/vehicles/1965FordMustangV8.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Benford3TonDumper.h
+++ b/src/vehicles/Benford3TonDumper.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/CAT3408OpenPipes.h
+++ b/src/vehicles/CAT3408OpenPipes.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/CaboverCAT3408.h
+++ b/src/vehicles/CaboverCAT3408.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Caterpillar323Excavator.h
+++ b/src/vehicles/Caterpillar323Excavator.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Chevy468.h
+++ b/src/vehicles/Chevy468.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ChevyNovaCoupeV8.h
+++ b/src/vehicles/ChevyNovaCoupeV8.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ChevyNovaCoupeV8_P407.h
+++ b/src/vehicles/ChevyNovaCoupeV8_P407.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/DefenderTd5.h
+++ b/src/vehicles/DefenderTd5.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/DefenderV8Automatic.h
+++ b/src/vehicles/DefenderV8Automatic.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/DefenderV8CrawlerAutomatic.h
+++ b/src/vehicles/DefenderV8CrawlerAutomatic.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/DefenderV8OpenPipeAutomatic.h
+++ b/src/vehicles/DefenderV8OpenPipeAutomatic.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/FordPowerstroke.h
+++ b/src/vehicles/FordPowerstroke.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/FreightlinerCummins350 2.h
+++ b/src/vehicles/FreightlinerCummins350 2.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/FreightlinerCummins350.h
+++ b/src/vehicles/FreightlinerCummins350.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/GAZ66.h
+++ b/src/vehicles/GAZ66.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/GMCsierra.h
+++ b/src/vehicles/GMCsierra.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/HarleyDavidsonFXSB.h
+++ b/src/vehicles/HarleyDavidsonFXSB.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/HiluxDiesel.h
+++ b/src/vehicles/HiluxDiesel.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/IS3.h
+++ b/src/vehicles/IS3.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/JaguarXJS.h
+++ b/src/vehicles/JaguarXJS.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/JaguarXJSautomatic.h
+++ b/src/vehicles/JaguarXJSautomatic.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/JeepGrandCherokeeTrackhawk.h
+++ b/src/vehicles/JeepGrandCherokeeTrackhawk.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/JeepWranglerRubicon392V8.h
+++ b/src/vehicles/JeepWranglerRubicon392V8.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/JeepWranglerRubicon392V8_2.h
+++ b/src/vehicles/JeepWranglerRubicon392V8_2.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/KenworthCummins335.h
+++ b/src/vehicles/KenworthCummins335.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/KenworthW900ACAT3408.h
+++ b/src/vehicles/KenworthW900ACAT3408.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/KenworthW900ACAT3408new.h
+++ b/src/vehicles/KenworthW900ACAT3408new.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/KenworthW900ADetroit8V71.h
+++ b/src/vehicles/KenworthW900ADetroit8V71.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/KirovetsK700.h
+++ b/src/vehicles/KirovetsK700.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/LaFerrari.h
+++ b/src/vehicles/LaFerrari.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/LandcruiserFJ40.h
+++ b/src/vehicles/LandcruiserFJ40.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/LandcruiserFJ40Diesel.h
+++ b/src/vehicles/LandcruiserFJ40Diesel.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/LandcruiserFJ40Diesel2.h
+++ b/src/vehicles/LandcruiserFJ40Diesel2.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/M35.h
+++ b/src/vehicles/M35.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MGBGtV8.h
+++ b/src/vehicles/MGBGtV8.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MackSuperLiner.h
+++ b/src/vehicles/MackSuperLiner.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MagirusDeutz256.h
+++ b/src/vehicles/MagirusDeutz256.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MagirusMercur125.h
+++ b/src/vehicles/MagirusMercur125.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ManKat.h
+++ b/src/vehicles/ManKat.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ManTgx.h
+++ b/src/vehicles/ManTgx.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MercedesActros1836.h
+++ b/src/vehicles/MercedesActros1836.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MercedesActrosV6.h
+++ b/src/vehicles/MercedesActrosV6.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/MesserschmittBf109.h
+++ b/src/vehicles/MesserschmittBf109.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/PeterbiltDetroit8v92.h
+++ b/src/vehicles/PeterbiltDetroit8v92.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/RAM2500_Cummins12V.h
+++ b/src/vehicles/RAM2500_Cummins12V.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/RAM2500_Cummins12Vautomatic.h
+++ b/src/vehicles/RAM2500_Cummins12Vautomatic.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Saurer2DM.h
+++ b/src/vehicles/Saurer2DM.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Scania143.h
+++ b/src/vehicles/Scania143.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ScaniaV8.h
+++ b/src/vehicles/ScaniaV8.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ScaniaV8Firetruck.h
+++ b/src/vehicles/ScaniaV8Firetruck.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/ScaniaV8_50ton.h
+++ b/src/vehicles/ScaniaV8_50ton.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Tatra813.h
+++ b/src/vehicles/Tatra813.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Tatra813new.h
+++ b/src/vehicles/Tatra813new.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/URAL375.h
+++ b/src/vehicles/URAL375.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/US_Firetruck.h
+++ b/src/vehicles/US_Firetruck.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/UnimogU1000.h
+++ b/src/vehicles/UnimogU1000.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/UnionPacific2002.h
+++ b/src/vehicles/UnionPacific2002.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Ural375D.h
+++ b/src/vehicles/Ural375D.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/Ural4320.h
+++ b/src/vehicles/Ural4320.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/VolvoFH16_750.h
+++ b/src/vehicles/VolvoFH16_750.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/VolvoFH16_OpenPipe.h
+++ b/src/vehicles/VolvoFH16_OpenPipe.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission.
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 // See: https://www.youtube.com/watch?v=MU1iwzl33Zw&list=LL&index=4
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------

--- a/src/vehicles/VwBeetle.h
+++ b/src/vehicles/VwBeetle.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------

--- a/src/vehicles/generic6zylDiesel.h
+++ b/src/vehicles/generic6zylDiesel.h
@@ -1,4 +1,6 @@
-// Vehicle specific settings for sound, lights, ESC, transmission. This master file is containing all available sounds
+#include <Arduino.h>
+
+// Vehicle specific settings for sound, lights, ESC, transmission. This is a vehicle specific file.
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------


### PR DESCRIPTION
This prevents warning messages from VS Code concerning "undefined types" for `uint8_t` and similar, when editing vehicle config files.

Also removed "This master file is containing all available sounds" from some of the vehicle files.